### PR TITLE
Support multiple requests per capture file

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,175 +11,186 @@
  * - Filter what we record up front?
  */
 var fs = require('fs'),
-    path = require('path');
+  path = require('path');
 
 module.exports = function harCaptureMiddlewareSetup(options) {
-    // Extract options
-    var mapRequestToName = options.mapRequestToName || function (req) {
-        return req.ip;
-    };
-    var saveRequestBody = !!options.saveRequestBody;
-    var harOutputDir = options.harOutputDir || process.cwd();
-    var filterFunction = options.filter || function (req) {
-        return true;
-    };
+  // Extract options
+  var mapRequestToName = options.mapRequestToName || function (req) {
+    return req.ip;
+  };
+  var saveRequestBody = !!options.saveRequestBody;
+  var harOutputDir = options.harOutputDir || process.cwd();
 
-    return function harCaptureMiddleware(req, res, next) {
-        // Filter out stuff we don't want to run
-        if (!filterFunction(req)) { return next(); }
+  // Default 10 minutes
+  var maxCaptureTime = (options.maxCaptureSeconds || 600) * 1000;
+  var maxCaptureRequests = options.maxCaptureRequests || 1000;
 
-        var startTime = Date.now(),
-            outputName = mapRequestToName(req);
+  var filterFunction = options.filter || function (req) {
+    return true;
+  };
 
-        // Listen in on body parsing
-        // NOTE: We do not resume the stream, as it would make actual parsers
-        // miss out on the data. On the down-side, it doesn't capture a body
-        // when the body isn't used later.
-        var requestBodySize = 0,
-            requestBody = [];
+  var entries = [];
+  var lastCaptureTime = Date.now();
 
-        req.on('data', function (chunck) {
-            requestBodySize += chunck.length;
-            if (saveRequestBody) {
-                requestBody.push(chunck);
-            }
+  return function harCaptureMiddleware(req, res, next) {
+    // Filter out stuff we don't want to run
+    if (!filterFunction(req)) { return next(); }
+
+    var startTime = Date.now(),
+      outputName = mapRequestToName(req);
+
+    // Listen in on body parsing
+    // NOTE: We do not resume the stream, as it would make actual parsers
+    // miss out on the data. On the down-side, it doesn't capture a body
+    // when the body isn't used later.
+    var requestBodySize = 0,
+      requestBody = [];
+
+    req.on('data', function (chunck) {
+      requestBodySize += chunck.length;
+      if (saveRequestBody) {
+        requestBody.push(chunck);
+      }
+    });
+    req.on('end', function (chunck) {
+      if (chunck) {
+        requestBodySize += chunck.length;
+        if (saveRequestBody) {
+          requestBody.push(chunck);
+        }
+      }
+
+      if (requestBody.length < 0) {
+        requestBody = "";
+        return;
+      }
+
+      if (Buffer.isBuffer(requestBody[0])) {
+        requestBody = Buffer.concat(requestBody).encode('base64');
+      } else {
+        requestBody = requestBody.join("");
+      }
+    });
+
+    // Shadow the 'end' request
+    var end = res.end;
+    res.end = function () {
+      var endTime = Date.now(),
+        deltaTime = endTime - startTime;
+      // Call the real 'end'
+      end.apply(res, arguments);
+
+      // Store har-stuff...
+
+      var reqEntry = {
+        timings: {
+          send: -1,
+          receive: -1,
+          wait: deltaTime,
+          comment: "Server-side processing only",
+          onLoad: -1,
+        },
+        startedDateTime: new Date(startTime).toISOString(),
+        time: deltaTime,
+        request: {
+          method: req.method,
+          url: req.protocol + '://' + req.get('host') + req.originalUrl,
+          httpVersion: 'HTTP/' + req.httpVersion,
+          headersSize: 0, // Filled out later
+          headers: [], // Filled out later
+          queryString: [], // TODO
+          cookies: [], // TODO
+          bodySize: requestBodySize,
+          content: {
+            size: requestBodySize,
+            text: requestBody,
+            comment: "Captured input stream"
+          }
+        },
+        response: {
+          status: res.statusCode,
+          redirectURL: req.originalUrl,
+          httpVersion: 'HTTP/' + req.httpVersion, // TODO
+          headersSize: -1,
+          statusText: 'OK', // TODO
+          headers: [],
+          cookies: [], // TODO
+          bodySize: -1, // TODO
+          content: { // TODO
+            size: -1,
+            mimeType: '',
+            compression: -1
+          },
+          timings: {
+            send: 0,
+            receive: 0,
+            wait: deltaTime,
+            comment: "Server-side processing only"
+          }
+        },
+        cache: {}, // TODO / is it optional
+        pageref: 'page' + startTime
+      };
+
+      // REQUEST DATA
+      // Fix up data-stucture with iterative data from request
+      // Headers
+      Object.keys(req.headers).forEach(function (headerName) {
+        reqEntry.request.headersSize += headerName.length + 2 + req.headers[headerName].length;
+        reqEntry.request.headers.push({
+          name: headerName,
+          value: req.headers[headerName]
         });
-        req.on('end', function (chunck) {
-            if (chunck) {
-                requestBodySize += chunck.length;
-                if (saveRequestBody) {
-                    requestBody.push(chunck);
-                }
-            }
-
-            if (requestBody.length < 0) {
-                requestBody = "";
-                return;
-            }
-
-            if (Buffer.isBuffer(requestBody[0])) {
-                requestBody = Buffer.concat(requestBody).encode('base64');
-            } else {
-                requestBody = requestBody.join("");
-            }
+      });
+      // Query strings
+      Object.keys(req.query).forEach(function (queryName) {
+        reqEntry.request.queryString.push({
+          name: queryName,
+          value: req.query[queryName]
         });
+      });
+      // TODO: Cookies
 
-        // Shadow the 'end' request
-        var end = res.end;
-        res.end = function () {
-            var endTime = Date.now(),
-                deltaTime = endTime - startTime;
-            // Call the real 'end'
-            end.apply(res, arguments);
+      // RESPONSE DATA
+      // Headers
+      if (res._headerSent) {
+        reqEntry.response.headersSize = res._header.length;
+        Object.keys(res._headers).forEach(function (headerName) {
+          var realHeaderName = res._headerNames[headerName] || headerName;
+          reqEntry.response.headers.push({
+            name: realHeaderName,
+            value: res._headers[headerName]
+          });
+        });
+      }
 
-            // Store har-stuff...
-            var data = {
-                log: {
-                    version: '1.1', // Version of HAR file-format
-                    creator: {
-                        name: 'node-express-har-capture',
-                        version: '0.0.0' // TODO: Get from package.json
-                        // comment: ""
-                    },
-                    pages: [{
-                        startedDateTime: new Date(startTime).toISOString(),
-                        id: 'page' + startTime,
-                        title: req.url,
-                        pageTimings: { onLoad: deltaTime }
-                    }],
-                    entries: [{
-                        timings: {
-                            send: -1,
-                            receive: -1,
-                            wait: deltaTime,
-                            comment: "Server-side processing only",
-                            onLoad: -1,
-                        },
-                        startedDateTime: new Date(startTime).toISOString(),
-                        time: deltaTime,
-                        request: {
-                            method: req.method,
-                            url: req.protocol + '://' + req.get('host') + req.originalUrl,
-                            httpVersion: 'HTTP/' + req.httpVersion,
-                            headersSize: 0, // Filled out later
-                            headers: [], // Filled out later
-                            queryString: [], // TODO
-                            cookies: [], // TODO
-                            bodySize: requestBodySize,
-                            content: {
-                                size: requestBodySize,
-                                text: requestBody,
-                                comment: "Captured input stream"
-                            }
-                        },
-                        response: {
-                            status: res.statusCode,
-                            redirectURL: req.originalUrl,
-                            httpVersion: 'HTTP/' + req.httpVersion, // TODO
-                            headersSize: -1,
-                            statusText: 'OK', // TODO
-                            headers: [],
-                            cookies: [], // TODO
-                            bodySize: -1, // TODO
-                            content: { // TODO
-                                size: -1,
-                                mimeType: '',
-                                compression: -1
-                            },
-                            timings: {
-                                send: 0,
-                                receive: 0,
-                                wait: deltaTime,
-                                comment: "Server-side processing only"
-                            }
-                        },
-                        cache: {}, // TODO / is it optional
-                        pageref: 'page' + startTime
-                    }]
-                }
-            };
+      entries.push(reqEntry);
 
-            // REQUEST DATA
-            // Fix up data-stucture with iterative data from request
-            // Headers
-            Object.keys(req.headers).forEach(function (headerName) {
-                data.log.entries[0].request.headersSize += headerName.length + 2 + req.headers[headerName].length;
-                data.log.entries[0].request.headers.push({
-                    name: headerName,
-                    value: req.headers[headerName]
-                });
-            });
-            // Query strings
-            Object.keys(req.query).forEach(function (queryName) {
-                data.log.entries[0].request.queryString.push({
-                    name: queryName,
-                    value: req.query[queryName]
-                });
-            });
-            // TODO: Cookies
-
-            // RESPONSE DATA
-            // Headers
-            if (res._headerSent) {
-                data.log.entries[0].response.headersSize = res._header.length;
-                Object.keys(res._headers).forEach(function (headerName) {
-                    var realHeaderName = res._headerNames[headerName] || headerName;
-                    data.log.entries[0].response.headers.push({
-                        name: realHeaderName,
-                        value: res._headers[headerName]
-                    });
-                });
+      var now = Date.now();
+      if (now - lastCaptureTime >= maxCaptureTime || entries.length >= maxCaptureRequests) {
+        // Write the data out
+        fs.writeFile(
+          path.join(harOutputDir, now.toString() + '-' + outputName + '.har'),
+          JSON.stringify({
+            log: {
+              version: '1.1', // Version of HAR file-format
+              creator: {
+                name: 'node-express-har-capture',
+                version: '0.1.0' // TODO: Get from package.json
+                // comment: ""
+              },
+              pages: [],
+              entries: entries
             }
+          }, undefined, 2)
+        );
 
-
-            // Write the data out
-            fs.writeFile(
-                path.join(harOutputDir, Date.now().toString() + '-' + outputName + '.har'),
-                JSON.stringify(data, undefined, 2)
-            );
-        };
-
-        // Continue processing the request
-        next();
+        entries = [];
+        lastCaptureTime = now;
+      }
     };
+
+    // Continue processing the request
+    next();
+  };
 };

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = function harCaptureMiddlewareSetup(options) {
       flush();
     }
     else {
-      lastTimer = setTimeout(flush, timeUntilFlush);
+      lastTimer = setTimeout(flush, timeUntilFlush).unref();
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-har-capture",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Express middleware for capturing HAR (HTTP ARchive)-files",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-har-capture",
-  "version": "1.0.0",
+  "version": "1.0.0-beta",
   "description": "Express middleware for capturing HAR (HTTP ARchive)-files",
   "main": "index.js",
   "scripts": {

--- a/test/filter.js
+++ b/test/filter.js
@@ -17,8 +17,12 @@ describe('Filter test', function () {
         app.use(har({
             maxCaptureRequests: 1,
             harOutputDir: __dirname,
-            mapRequestToName: function (req) {
-                return req.headers.filename || 'default';
+            mapHarToName: function (har) {
+              var filenameHeader = har.log.entries[0].request.headers.find(function (header) {
+                return header.name === 'filename';
+              });
+
+              return (filenameHeader && filenameHeader.value) || 'default';
             },
             filter: function (req) { return 'get-har' in req.headers; }
         }));

--- a/test/filter.js
+++ b/test/filter.js
@@ -15,6 +15,7 @@ describe('Filter test', function () {
         app = express();
 
         app.use(har({
+            maxCaptureRequests: 1,
             harOutputDir: __dirname,
             mapRequestToName: function (req) {
                 return req.headers.filename || 'default';

--- a/test/requestBody.js
+++ b/test/requestBody.js
@@ -15,6 +15,7 @@ describe('Request bodies', function () {
         app = express();
 
         app.use(har({
+            maxCaptureRequests: 1,
             harOutputDir: __dirname,
             saveRequestBody: true 
         }));

--- a/test/simple.js
+++ b/test/simple.js
@@ -15,6 +15,7 @@ describe('Simple test', function () {
         app = express();
 
         app.use(har({
+            maxCaptureRequests: 2,
             harOutputDir: __dirname
         }));
 
@@ -38,33 +39,40 @@ describe('Simple test', function () {
     });
 
     it('Sends requests', function (done) {
+      request(app)
+      .get('/')
+      .set('Custom-header', 'foo/bar')
+      .expect(200)
+      .end(function (err, res) {
         request(app)
-            .get('/')
-            .set('Custom-header', 'foo/bar')
-            .expect(200)
-            .end(function (err, res) {
-                // Wait for file to be written to disk
-                setTimeout(function () {
-                    var filename = fs.readdirSync(__dirname).filter(function (filename) {
-                        return filename.indexOf('.har') > 10;
-                    })[0];
+        .get('/')
+        .set('Custom-header', 'foo/bar')
+        .expect(200)
+        .end(function (err, res) {
+          // Wait for file to be written to disk
+          setTimeout(function () {
+            var filename = fs.readdirSync(__dirname).filter(function (filename) {
+              return filename.indexOf('.har') > 10;
+            })[0];
 
-                    // It is valid JSON
-                    var json;
-                    try {
-                        var fullFilename = path.join(__dirname, filename),
-                            data = fs.readFileSync(fullFilename);
-                        json = JSON.parse(data);
-                    } catch (e) {
-                        assert(e, 'Could not parse JSON');
-                        return done(e);
-                    }
+            // It is valid JSON
+            var json;
+            try {
+              var fullFilename = path.join(__dirname, filename),
+                data = fs.readFileSync(fullFilename);
+              json = JSON.parse(data);
+            } catch (e) {
+              assert(e, 'Could not parse JSON');
+              return done(e);
+            }
 
-                    // Simple sanity check
-                    assert.deepProperty(json, 'log.entries.0');
+            // Simple sanity check
+            assert.deepProperty(json, 'log.entries.0');
+            assert.deepProperty(json, 'log.entries.1');
 
-                    done(err);
-                }, 5);
-            });
+            done(err);
+          }, 5);
+        });
+      });
     });
 });


### PR DESCRIPTION
Support multiple requests per HAR file with configurable defaults of `maxCaptureRequests = 1000` and `maxCaptureSeconds = 600` (ten minutes).

I.e. by default the captured requests are written to a file whenever 10 minutes have passed since the last write or 1000 requests have been captured (which ever happens first).

Exposed `flushBeforeRequest` and `flushAfterRequest` options that may be used to force a flush to file before or after a certain request (e.g. login, logout, etc). 